### PR TITLE
SDEVX-11154

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,5 +72,5 @@ inputs:
     default: 'true'
     required: false   
 runs:
-  using: 'node24'
+  using: 'node20'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,10 @@ inputs:
     description: 'Enable or disable debug mode'
     required: false
     default: false
+  waitForScanCompletion:
+    description: 'Wait for the Veracode Static Scan to complete and poll for the final results. If set to false, the scan will be submitted asynchronously and the workflow will continue immediately.'
+    default: 'true'
+    required: false   
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -72,5 +72,5 @@ inputs:
     default: 'true'
     required: false   
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ const gitRepositoryUrl = core.getInput('gitRepositoryUrl', { required: false });
 const platformType = core.getInput('platformType', { required: false });
 const workflowApp = core.getInput('workflowApp', {required: false});
 const debug = core.getInput('debug', {required: false});
+const waitForScanCompletion = core.getInput('waitForScanCompletion', {required: false});
 
 const POLICY_EVALUATION_FAILED = 9;
 const SCAN_TIME_OUT = 8;
@@ -60,7 +61,7 @@ async function run() {
     return;
 
   if (workflowApp){
-      await executeStaticScans(vid, vkey, appname, policy, teams, createprofile, gitRepositoryUrl, sandboxname, version, filepath, responseCode, createsandbox, failbuild, debug, scantimeout);
+      await executeStaticScans(vid, vkey, appname, policy, teams, createprofile, gitRepositoryUrl, sandboxname, version, filepath, responseCode, createsandbox, failbuild, debug, scantimeout, waitForScanCompletion);
       return;
   }  
 

--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ async function run() {
     return;
 
   if (workflowApp){
-      await executeStaticScans(vid, vkey, appname, policy, teams, createprofile, gitRepositoryUrl, sandboxname, version, filepath, responseCode, createsandbox, failbuild, debug);
+      await executeStaticScans(vid, vkey, appname, policy, teams, createprofile, gitRepositoryUrl, sandboxname, version, filepath, responseCode, createsandbox, failbuild, debug, scantimeout);
       return;
   }  
 

--- a/src/services/workflow-service.js
+++ b/src/services/workflow-service.js
@@ -122,7 +122,8 @@ async function executePolicyScan(vid, vkey, veracodeApp, jarName, version, filep
     core.debug(stdout);
     core.debug(stderr);
   }
-
+  core.info(`waitForScanCompletion flag is set to: ${waitForScanCompletion}`);
+  core.info(waitForScanCompletion == false);
   if (waitForScanCompletion == false) {
     core.info('Static Scan Submitted, please check Veracode Platform for results');
     return;

--- a/src/services/workflow-service.js
+++ b/src/services/workflow-service.js
@@ -122,9 +122,8 @@ async function executePolicyScan(vid, vkey, veracodeApp, jarName, version, filep
     core.debug(stdout);
     core.debug(stderr);
   }
-  core.info(`waitForScanCompletion flag is set to: ${waitForScanCompletion}`);
-  core.info(waitForScanCompletion == false);
-  if (waitForScanCompletion == false) {
+
+  if (String(inputs.waitForScanCompletion).toLowerCase() === 'false') {
     core.info('Static Scan Submitted, please check Veracode Platform for results');
     return;
   }

--- a/src/services/workflow-service.js
+++ b/src/services/workflow-service.js
@@ -122,8 +122,10 @@ async function executePolicyScan(vid, vkey, veracodeApp, jarName, version, filep
     core.debug(stdout);
     core.debug(stderr);
   }
-
-  if(scantimeout === 0) {
+  core.info('Checking for results...');
+  core.info(scantimeout == 0);
+  core.info(scantimeout == '0');
+  if(scantimeout == 0 || scantimeout == '0'){
     core.info('Static Scan Submitted, please check Veracode Platform for results');
     return;
   }

--- a/src/services/workflow-service.js
+++ b/src/services/workflow-service.js
@@ -14,7 +14,7 @@ const { calculateAuthorizationHeader } = require('../api/veracode-hmac.js');
 const SCAN_TIME_OUT = 8;
 const POLICY_EVALUATION_FAILED = 9;
 
-async function executeStaticScans(vid, vkey, appname, policy, teams, createprofile, gitRepositoryUrl, sandboxname, version, filepath, responseCode, createsandbox, failbuild, debug) {
+async function executeStaticScans(vid, vkey, appname, policy, teams, createprofile, gitRepositoryUrl, sandboxname, version, filepath, responseCode, createsandbox, failbuild, debug, scantimeout) {
   core.info(`Getting Veracode Application for Policy Scan: ${appname}`)
   const veracodeApp = await getVeracodeApplicationForPolicyScan(vid, vkey, appname, policy, teams, createprofile, gitRepositoryUrl, debug);
   if (veracodeApp.appId === -1) {
@@ -89,7 +89,7 @@ async function executeStaticScans(vid, vkey, appname, policy, teams, createprofi
       core.info(`Running a Policy Scan: ${appname}`);
       //comand for policy scan 
       core.info(`Veracode Policy Scan Created, Build Id: ${version}`);
-      await executePolicyScan(vid, vkey, veracodeApp, jarName, version, filepath, responseCode, failbuild, debug)
+      await executePolicyScan(vid, vkey, veracodeApp, jarName, version, filepath, responseCode, failbuild, debug, scantimeout)
     }
   } catch (error) {
     console.log(error)
@@ -99,11 +99,11 @@ async function executeStaticScans(vid, vkey, appname, policy, teams, createprofi
 
 }
 
-async function executePolicyScan(vid, vkey, veracodeApp, jarName, version, filepath, responseCode, failbuild, debug) {
+async function executePolicyScan(vid, vkey, veracodeApp, jarName, version, filepath, responseCode, failbuild, debug, scantimeout) {
   const debugFlag = debug ? ' -debug' : '';
   if (debug)
     core.debug(`Module: workflow-service, function: executePolicyScan. Application: ${veracodeApp.appId}`);
-  const policyScanCommand = `java -jar ${jarName} -action UploadAndScanByAppId -vid ${vid} -vkey ${vkey} -appid ${veracodeApp.appId} -filepath ${filepath} -version ${version} -scanpollinginterval 30 -autoscan true -scanallnonfataltoplevelmodules true -includenewmodules true -scantimeout 6000 -deleteincompletescan 2${debugFlag}`;
+  const policyScanCommand = `java -jar ${jarName} -action UploadAndScanByAppId -vid ${vid} -vkey ${vkey} -appid ${veracodeApp.appId} -filepath ${filepath} -version ${version} -scanpollinginterval 30 -autoscan true -scanallnonfataltoplevelmodules true -includenewmodules true -scantimeout ${scantimeout} -deleteincompletescan 2${debugFlag}`;
   let scan_id = "";
   let sandboxID;
   let sandboxGUID;

--- a/src/services/workflow-service.js
+++ b/src/services/workflow-service.js
@@ -103,7 +103,8 @@ async function executePolicyScan(vid, vkey, veracodeApp, jarName, version, filep
   const debugFlag = debug ? ' -debug' : '';
   if (debug)
     core.debug(`Module: workflow-service, function: executePolicyScan. Application: ${veracodeApp.appId}`);
-  const policyScanCommand = `java -jar ${jarName} -action UploadAndScanByAppId -vid ${vid} -vkey ${vkey} -appid ${veracodeApp.appId} -filepath ${filepath} -version ${version} -scanpollinginterval 30 -autoscan true -scanallnonfataltoplevelmodules true -includenewmodules true -scantimeout ${scantimeout} -deleteincompletescan 2${debugFlag}`;
+  // const policyScanCommand = `java -jar ${jarName} -action UploadAndScanByAppId -vid ${vid} -vkey ${vkey} -appid ${veracodeApp.appId} -filepath ${filepath} -version ${version} -scanpollinginterval 30 -autoscan true -scanallnonfataltoplevelmodules true -includenewmodules true -scantimeout ${scantimeout} -deleteincompletescan 2${debugFlag}`;
+  const policyScanCommand = `java -jar ${jarName} -action UploadAndScan -vid ${vid} -vkey ${vkey} -appname BulkScan-4 -createprofile true -filepath ${filepath} -version ${version} -scantimeout ${scantimeout}`;
   let scan_id = "";
   let sandboxID;
   let sandboxGUID;

--- a/src/services/workflow-service.js
+++ b/src/services/workflow-service.js
@@ -123,7 +123,7 @@ async function executePolicyScan(vid, vkey, veracodeApp, jarName, version, filep
     core.debug(stderr);
   }
 
-  if (String(inputs.waitForScanCompletion).toLowerCase() === 'false') {
+  if (String(waitForScanCompletion).toLowerCase() === 'false') {
     core.info('Static Scan Submitted, please check Veracode Platform for results');
     return;
   }

--- a/src/services/workflow-service.js
+++ b/src/services/workflow-service.js
@@ -103,8 +103,8 @@ async function executePolicyScan(vid, vkey, veracodeApp, jarName, version, filep
   const debugFlag = debug ? ' -debug' : '';
   if (debug)
     core.debug(`Module: workflow-service, function: executePolicyScan. Application: ${veracodeApp.appId}`);
-  // const policyScanCommand = `java -jar ${jarName} -action UploadAndScanByAppId -vid ${vid} -vkey ${vkey} -appid ${veracodeApp.appId} -filepath ${filepath} -version ${version} -scanpollinginterval 30 -autoscan true -scanallnonfataltoplevelmodules true -includenewmodules true -scantimeout ${scantimeout} -deleteincompletescan 2${debugFlag}`;
-  const policyScanCommand = `java -jar ${jarName} -action UploadAndScan -vid ${vid} -vkey ${vkey} -appname BulkScan-4 -createprofile true -filepath ${filepath} -version ${version} -scantimeout ${scantimeout}`;
+  const policyScanCommand = `java -jar ${jarName} -action UploadAndScanByAppId -vid ${vid} -vkey ${vkey} -appid ${veracodeApp.appId} -filepath ${filepath} -version ${version} -scanpollinginterval 30 -autoscan true -scanallnonfataltoplevelmodules true -includenewmodules true -scantimeout ${scantimeout} -deleteincompletescan 2${debugFlag}`;
+  // const policyScanCommand = `java -jar ${jarName} -action UploadAndScan -vid ${vid} -vkey ${vkey} -appname BulkScan-4 -createprofile true -filepath ${filepath} -version ${version} -scantimeout ${scantimeout}`;
   let scan_id = "";
   let sandboxID;
   let sandboxGUID;
@@ -122,10 +122,8 @@ async function executePolicyScan(vid, vkey, veracodeApp, jarName, version, filep
     core.debug(stdout);
     core.debug(stderr);
   }
-  core.info('Checking for results...');
-  core.info(scantimeout == 0);
-  core.info(scantimeout == '0');
-  if(scantimeout == 0 || scantimeout == '0'){
+  core.info('Checking for results.....');
+  if(scantimeout == 0){
     core.info('Static Scan Submitted, please check Veracode Platform for results');
     return;
   }

--- a/src/services/workflow-service.js
+++ b/src/services/workflow-service.js
@@ -121,6 +121,12 @@ async function executePolicyScan(vid, vkey, veracodeApp, jarName, version, filep
     core.debug(stdout);
     core.debug(stderr);
   }
+
+  if(scantimeout === 0) {
+    core.info('Static Scan Submitted, please check Veracode Platform for results');
+    return;
+  }
+  
   if (stdout) {
     scan_id = extractValue(
         stdout,

--- a/src/services/workflow-service.js
+++ b/src/services/workflow-service.js
@@ -14,7 +14,7 @@ const { calculateAuthorizationHeader } = require('../api/veracode-hmac.js');
 const SCAN_TIME_OUT = 8;
 const POLICY_EVALUATION_FAILED = 9;
 
-async function executeStaticScans(vid, vkey, appname, policy, teams, createprofile, gitRepositoryUrl, sandboxname, version, filepath, responseCode, createsandbox, failbuild, debug, scantimeout) {
+async function executeStaticScans(vid, vkey, appname, policy, teams, createprofile, gitRepositoryUrl, sandboxname, version, filepath, responseCode, createsandbox, failbuild, debug, scantimeout, waitForScanCompletion) {
   core.info(`Getting Veracode Application for Policy Scan: ${appname}`)
   const veracodeApp = await getVeracodeApplicationForPolicyScan(vid, vkey, appname, policy, teams, createprofile, gitRepositoryUrl, debug);
   if (veracodeApp.appId === -1) {
@@ -89,7 +89,7 @@ async function executeStaticScans(vid, vkey, appname, policy, teams, createprofi
       core.info(`Running a Policy Scan: ${appname}`);
       //comand for policy scan 
       core.info(`Veracode Policy Scan Created, Build Id: ${version}`);
-      await executePolicyScan(vid, vkey, veracodeApp, jarName, version, filepath, responseCode, failbuild, debug, scantimeout)
+      await executePolicyScan(vid, vkey, veracodeApp, jarName, version, filepath, responseCode, failbuild, debug, scantimeout, waitForScanCompletion)
     }
   } catch (error) {
     console.log(error)
@@ -99,7 +99,7 @@ async function executeStaticScans(vid, vkey, appname, policy, teams, createprofi
 
 }
 
-async function executePolicyScan(vid, vkey, veracodeApp, jarName, version, filepath, responseCode, failbuild, debug, scantimeout) {
+async function executePolicyScan(vid, vkey, veracodeApp, jarName, version, filepath, responseCode, failbuild, debug, scantimeout, waitForScanCompletion) {
   const debugFlag = debug ? ' -debug' : '';
   if (debug)
     core.debug(`Module: workflow-service, function: executePolicyScan. Application: ${veracodeApp.appId}`);
@@ -122,8 +122,8 @@ async function executePolicyScan(vid, vkey, veracodeApp, jarName, version, filep
     core.debug(stdout);
     core.debug(stderr);
   }
-  core.info('Checking for results.....');
-  if(scantimeout == 0){
+
+  if (waitForScanCompletion == false) {
     core.info('Static Scan Submitted, please check Veracode Platform for results');
     return;
   }


### PR DESCRIPTION
1. Added a flag to control whether the workflow should wait for the Veracode Static Scan to complete and poll for the final results. If set to `false`, the scan will be submitted asynchronously and the workflow will continue immediately.

2. Fixed the `scantimeout` handling to use the configured value dynamically instead of the previously hardcoded value of `6000`.
